### PR TITLE
Bump dependencies 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.8.5</version>
+      <version>3.8.6</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.12</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.1</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
         <configuration>
           <debug>true</debug>
           <settingsFile>src/it/settings.xml</settingsFile>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.1.0</version>
+      <version>4.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
* Bump nexus-staging-maven-plugin from 1.6.12 to 1.6.13 - Closes #145 
* Bump mockito-core from 4.1.0 to 4.7.0 - Closes #153 
* Bump maven-javadoc-plugin from 3.3.2 to 3.4.1 - Closes #152 
* Bump maven-invoker-plugin from 3.2.2 to 3.3.0 - Closes #148 
* Bump maven-plugin-api from 3.8.5 to 3.8.6 - Closes #151 